### PR TITLE
update urls

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -9,9 +9,9 @@
   <maintainer email="130s@lateeye.net">Isaac Saito</maintainer>
   <license>BSD</license>
 
-  <url type="website">http://ros.org/wiki/rqt_launch</url>
-  <url type="repository">https://github.com/ros-visualization/rqt_common_plugins</url>
-  <url type="bugtracker">https://github.com/ros-visualization/rqt_common_plugins/issues</url>
+  <url type="website">http://wiki.ros.org/rqt_launch</url>
+  <url type="repository">https://github.com/ros-visualization/rqt_launch</url>
+  <url type="bugtracker">https://github.com/ros-visualization/rqt_launch/issues</url>
 
   <author>Isaac Saito</author>
   <author>Stuart Glaser</author>


### PR DESCRIPTION
With the plugin being split out from `rqt_common_plugins` I will do a last release for Lunar (as well as re-release for Kinetic, Jade, and Indigo) in the next days. After that I will stop watching this repo, not look at issues and pull requests, and not perform new releases.

Someone needs to take over the maintenance role which specifically includes doing new releases. @130s You are currently listed in the manifest as the maintainer. I am not sure if you want to take this role and fully take over this repository? Or anyone else would like to step up (@rsinnet @ablasdel @cottsay @mrdanbrooks since you have contributed to the package in the past)?

Please let me know if you want to be added / removed from the list of maintainers in the manifest. Otherwise I will go ahead and merge this as-is and release the package a last time setting the maintenance status to `unmaintained`.